### PR TITLE
mongo connection host via env var

### DIFF
--- a/bycon/beaconServer/cohorts.py
+++ b/bycon/beaconServer/cohorts.py
@@ -55,7 +55,7 @@ def _return_cohorts_response(byc):
     if not "cohort" in byc["response_entity_id"]:
         return
 
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 
     cohorts =  []
     c_id = byc.get("request_entity_path_id_value")

--- a/bycon/lib/data_retrieval.py
+++ b/bycon/lib/data_retrieval.py
@@ -1,4 +1,5 @@
 from pymongo import MongoClient
+from os import environ
 
 ################################################################################
 
@@ -17,7 +18,7 @@ def retrieve_data(ds_id, byc):
         r_s_res = retrieve_variants(ds_id, byc)
         return r_s_res
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = mongo_client[ ds_id ]
     data_coll = mongo_client[ ds_id ][ r_c ]
 
@@ -42,7 +43,7 @@ def retrieve_variants(ds_id, byc):
         if byc["method"] in byc["service_config"]["all_variants_methods"]:
             return False
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = mongo_client[ ds_id ]
     v_coll = mongo_client[ ds_id ][ "variants" ]
 

--- a/bycon/lib/dataset_parsing.py
+++ b/bycon/lib/dataset_parsing.py
@@ -1,5 +1,6 @@
 import pymongo
 import re
+from os import environ
 
 from bycon.lib.cgi_parsing import rest_path_value
 
@@ -45,7 +46,7 @@ def ds_id_from_accessid(byc):
     if any(x is False for x in [accessid, services_db, ho_collname]):
         return False
 
-    ho_client = pymongo.MongoClient()
+    ho_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     h_o = ho_client[services_db][ho_collname].find_one({"id": accessid})
     if not h_o:
         return False

--- a/bycon/lib/export_file_generation.py
+++ b/bycon/lib/export_file_generation.py
@@ -1,4 +1,5 @@
 import pymongo
+from os import environ
 
 from cgi_parsing import *
 from datatable_utils import get_nested_value
@@ -10,7 +11,7 @@ from response_remapping import de_vrsify_variant
 
 def export_variants_download(ds_id, byc):
 
-    data_client = pymongo.MongoClient()
+    data_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     v_coll = data_client[ ds_id ][ "variants" ]
     ds_results = byc["dataset_results"][ds_id]
  
@@ -39,7 +40,7 @@ def stream_pgx_meta_header(ds_id, ds_results, byc):
     s_r_rs = byc["service_response"]["response"]["result_sets"][0]
     b_p = byc["pagination"]
 
-    mongo_client = pymongo.MongoClient()
+    mongo_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     bs_coll = mongo_client[ ds_id ][ "biosamples" ]
 
     open_text_streaming(byc["env"])
@@ -149,7 +150,7 @@ def print_filters_meta_line(byc):
 
 def export_pgxseg_download(ds_id, byc):
 
-    data_client = pymongo.MongoClient()
+    data_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     v_coll = data_client[ ds_id ][ "variants" ]
     ds_results = byc["dataset_results"][ds_id]
     v__ids = byc["dataset_results"][ds_id]["variants._id"].get("target_values", [])
@@ -211,7 +212,7 @@ def export_callsets_matrix(ds_id, byc):
 
     cs_r = ds_results["callsets._id"]
 
-    mongo_client = pymongo.MongoClient()
+    mongo_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     bs_coll = mongo_client[ ds_id ][ "biosamples" ]
     cs_coll = mongo_client[ ds_id ][ "callsets" ]
 

--- a/bycon/lib/handover_generation.py
+++ b/bycon/lib/handover_generation.py
@@ -132,7 +132,7 @@ def query_results_save_handovers(byc):
 
 def dataset_results_save_handovers(ds_id, byc):
 
-    ho_client = MongoClient()
+    ho_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     ho_db = ho_client[ byc["config"]["services_db"] ]
     ho_coll = ho_db[ byc["config"][ "handover_coll" ] ]
 
@@ -235,7 +235,7 @@ def _write_variants_bedfile(h_o, p_f, p_t, byc):
 
     vs = { "DUP": [ ], "DEL": [ ], "LOH": [ ], "SNV": [ ]}
 
-    data_client = MongoClient( )
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ ds_id ]
     data_coll = data_db[ h_o["target_collection"] ]
 

--- a/bycon/lib/query_execution.py
+++ b/bycon/lib/query_execution.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 from pymongo import MongoClient
-
+from os import environ
 from cgi_parsing import cgi_debug_message, test_truthy
 
 
@@ -10,7 +10,7 @@ def mongo_result_list(db_name, coll_name, query, fields):
     results = []
     error = False
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 
     try:
         results = list(mongo_client[db_name][coll_name].find(query, fields))
@@ -38,7 +38,7 @@ def execute_bycon_queries(ds_id, byc):
     if "dataset_results" not in byc.keys():
         byc.update({"dataset_results": {}})
 
-    data_client = MongoClient()
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ds_id]
     data_collnames = data_db.list_collection_names()
 

--- a/bycon/lib/query_generation.py
+++ b/bycon/lib/query_generation.py
@@ -1,4 +1,5 @@
 import pymongo
+from os import environ
 from bson import SON
 
 from bycon_helpers import days_from_iso8601duration 
@@ -62,7 +63,7 @@ def _replace_queries_in_test_mode(byc):
     ret_no = int(byc.get('test_mode_count', 5))
 
     ds_id = byc["dataset_ids"][0]
-    mongo_client = pymongo.MongoClient()
+    mongo_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = mongo_client[ds_id]
     data_collnames = data_db.list_collection_names()
 
@@ -160,7 +161,7 @@ def _update_queries_from_hoid(byc):
     if "accessid" in byc["form_data"]:
 
         accessid = byc["form_data"]["accessid"]
-        ho_client = pymongo.MongoClient()
+        ho_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
         ho_db = ho_client[byc["config"]["services_db"]]
         ho_coll = ho_db[byc["config"]["handover_coll"]]
         h_o = ho_coll.find_one({"id": accessid})
@@ -214,7 +215,7 @@ def _update_queries_from_filters(byc, ds_id="progenetix"):
     f_desc = byc["filter_flags"]["descendants"]
     # precision = byc[ "filter_flags" ][ "precision" ]
 
-    mongo_client = pymongo.MongoClient()
+    mongo_client = pymongo.MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     coll_coll = mongo_client[ds_id][byc["config"]["collations_coll"]]
 
     filters = byc.get("filters", [])

--- a/bycon/lib/read_specs.py
+++ b/bycon/lib/read_specs.py
@@ -1,6 +1,6 @@
 import re, yaml, json
 from pymongo import MongoClient
-from os import path, pardir, scandir
+from os import path, pardir, scandir, environ
 from pathlib import Path
 from json_ref_dict import RefDict, materialize
 from humps import camelize, decamelize
@@ -78,7 +78,7 @@ def dbstats_return_latest(byc):
 
     db = byc[ "config" ][ "services_db" ]
     coll = byc[ "config" ][ "beacon_info_coll" ]
-    stats = MongoClient( )[ db ][ coll ].find( { }, { "_id": 0 } ).sort( "date", -1 ).limit( limit )
+    stats = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))[ db ][ coll ].find( { }, { "_id": 0 } ).sort( "date", -1 ).limit( limit )
 
     return stats
 

--- a/bycon/lib/response_remapping.py
+++ b/bycon/lib/response_remapping.py
@@ -2,6 +2,7 @@ import datetime, re
 from pymongo import MongoClient
 from cgi_parsing import *
 from interval_utils import interval_counts_from_callsets
+from os import environ
 
 ################################################################################
 ################################################################################
@@ -361,7 +362,7 @@ def remap_phenopackets(ds_id, r_s_res, byc):
     if not "phenopacket" in byc["response_entity_id"]:
         return r_s_res
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = mongo_client[ds_id]
     pxf_s = []
 
@@ -513,7 +514,7 @@ def remap_all(r_s_res):
 ################################################################################
 
 def callset__ids_create_iset(ds_id, label, cs__ids, byc):
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     cs_coll = mongo_client[ds_id]["callsets"]
 
     cs_cursor = cs_coll.find({"_id": {"$in": cs__ids}, "variant_class": {"$ne": "SNV"}})

--- a/bycon/lib/service_utils.py
+++ b/bycon/lib/service_utils.py
@@ -855,7 +855,7 @@ def check_callset_plot_delivery(byc):
             continue
 
         v_d = byc["variant_parameters"]
-        mongo_client = MongoClient()
+        mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
         cs_coll = mongo_client[ds_id]["callsets"]
         var_coll = mongo_client[ds_id]["variants"]
 
@@ -925,7 +925,7 @@ def check_computed_histoplot_delivery(byc):
         if not "callsets._id" in ds_results:
             continue
 
-        mongo_client = MongoClient()
+        mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
         bios_coll = mongo_client[ds_id]["biosamples"]
         cs_coll = mongo_client[ds_id]["callsets"]
 
@@ -997,7 +997,7 @@ def check_computed_interval_frequency_delivery(byc):
 
     cs_r = ds_results["callsets._id"]
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     cs_coll = mongo_client[ds_id]["callsets"]
 
     open_text_streaming(byc["env"], "interval_cnv_frequencies.pgxseg")


### PR DESCRIPTION
`MongoClient` now respects env var `BYCON_MONGO_HOST`. If var not set, default to `localhost`. 

I have only tested this with `BYCON_MONGO_HOST` set. Please double-check that the current functionality is retained if the var is not set.